### PR TITLE
Add PlanPilot base, index, results templates and styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv/
 __pycache__/
 *.pyc
 .DS_Store
+.venv/

--- a/pathpilot-backend/app.py
+++ b/pathpilot-backend/app.py
@@ -1,7 +1,6 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template
 from dotenv import load_dotenv
 from routes.jobs import jobs_bp
-
 from metrics import get_metrics, init_db
 
 load_dotenv()
@@ -12,13 +11,21 @@ app.register_blueprint(jobs_bp)
 
 init_db()
 
+
 @app.route("/")
 def home():
-    return "PathPilot web-app is running"
+    return render_template("index.html")
+
+
+@app.route("/results")
+def results():
+    return render_template("results.html")
+
 
 @app.route("/metrics")
 def metrics():
     return jsonify(get_metrics())
+
 
 # do not change the host (specific to Docker)
 # allows Flask to accept connections from anywhere including Docker's internals.

--- a/pathpilot-frontend/static/css/style.css
+++ b/pathpilot-frontend/static/css/style.css
@@ -1,0 +1,260 @@
+:root {
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --surface-soft: #eef3ff;
+  --text: #172033;
+  --muted: #5f6b85;
+  --line: #d9e1f0;
+  --primary: #3457eb;
+  --primary-dark: #2440b8;
+  --accent: #dbe4ff;
+  --success: #1c8b5f;
+  --radius: 18px;
+  --shadow: 0 16px 40px rgba(34, 52, 96, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  color: var(--text);
+  background: linear-gradient(180deg, #f8fbff 0%, #f3f6fb 100%);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.container {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(245, 247, 251, 0.88);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(217, 225, 240, 0.75);
+}
+
+.nav-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+.brand {
+  font-size: 1.35rem;
+  font-weight: 800;
+}
+
+.eyebrow,
+.label {
+  color: var(--primary);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.2rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.hero,
+.section {
+  padding: 4.5rem 0;
+}
+
+.hero-grid,
+.two-up,
+.three-up {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-grid,
+.two-up {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.three-up {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.hero h1,
+.results-hero h1 {
+  font-size: clamp(2.4rem, 5vw, 4.5rem);
+  line-height: 1.02;
+  margin: 0.5rem 0 1rem;
+  max-width: 10ch;
+}
+
+.lead {
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  max-width: 62ch;
+}
+
+.narrow {
+  max-width: 58ch;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--surface-soft);
+  color: var(--primary-dark);
+  border: 1px solid var(--accent);
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.75rem;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.95rem 1.2rem;
+  border-radius: 14px;
+  font-weight: 700;
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: white;
+}
+
+.btn-secondary {
+  background: white;
+  border: 1px solid var(--line);
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid rgba(217, 225, 240, 0.9);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+}
+
+.summary-card h2,
+.section-heading h2,
+.roadmap-card h2,
+.result-card h2 {
+  margin-top: 0.35rem;
+  margin-bottom: 0.85rem;
+}
+
+.stats-list,
+.bullet-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.stats-list li,
+.course-list div,
+.salary-stack div,
+.timeline-item,
+tbody tr {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.stats-list li:last-child,
+.course-list div:last-child,
+.salary-stack div:last-child,
+tbody tr:last-child {
+  border-bottom: 0;
+}
+
+.feature-card p,
+.result-card p,
+.timeline-item p,
+.roadmap-card p {
+  color: var(--muted);
+}
+
+.muted-section {
+  background: linear-gradient(180deg, rgba(219, 228, 255, 0.28), rgba(245, 247, 251, 0));
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+}
+
+th {
+  font-size: 0.84rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.accent-border {
+  outline: 2px solid rgba(52, 87, 235, 0.2);
+}
+
+@media (max-width: 860px) {
+  .hero-grid,
+  .two-up,
+  .three-up {
+    grid-template-columns: 1fr;
+  }
+
+  .nav-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.8rem;
+  }
+
+  .hero,
+  .section {
+    padding: 3rem 0;
+  }
+
+  .hero h1,
+  .results-hero h1 {
+    max-width: 100%;
+  }
+}

--- a/pathpilot-frontend/templates/base.html
+++ b/pathpilot-frontend/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}PlanPilot{% endblock %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container nav-row">
+      <div>
+        <p class="eyebrow">Degree + career planner</p>
+        <a class="brand" href="/">PlanPilot</a>
+      </div>
+
+      <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/results">Results</a>
+        <a href="#planner">Planner</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/pathpilot-frontend/templates/index.html
+++ b/pathpilot-frontend/templates/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PlanPilot | Home</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../static/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container nav-row">
+      <div>
+        <p class="eyebrow">Degree + career planner</p>
+        <a class="brand" href="#">PlanPilot</a>
+      </div>
+      <nav class="nav-links">
+        <a href="#">Home</a>
+        <a href="results.html">Results</a>
+        <a href="#planner">Planner</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <p class="pill">Mock demo data enabled</p>
+          <h1>Plan your degree path and preview the careers it unlocks.</h1>
+          <p class="lead">
+            PlanPilot helps students compare majors, map semester-by-semester courses,
+            and estimate career outcomes like salary ranges, job titles, and skill alignment.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="results.html">View sample results</a>
+            <a class="btn btn-secondary" href="#planner">See planner overview</a>
+          </div>
+        </div>
+
+        <aside class="panel summary-card">
+          <h2>Sample student</h2>
+          <ul class="stats-list">
+            <li><span>Target</span><strong>Cybersecurity A.A.S.</strong></li>
+            <li><span>Credits complete</span><strong>27 / 60</strong></li>
+            <li><span>Estimated finish</span><strong>Spring 2027</strong></li>
+            <li><span>Top role</span><strong>Security Analyst</strong></li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section" id="planner">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Planner snapshot</p>
+          <h2>What the app can show</h2>
+        </div>
+
+        <div class="card-grid three-up">
+          <article class="panel feature-card">
+            <h3>Path optimizer</h3>
+            <p>
+              Recommend the fastest path to a degree or certificate using completed credits,
+              prerequisites, and remaining course rules.
+            </p>
+          </article>
+
+          <article class="panel feature-card">
+            <h3>Career outcomes</h3>
+            <p>
+              Preview likely roles like data analyst, IT support specialist, and junior developer
+              with salary bands and skill matches.
+            </p>
+          </article>
+
+          <article class="panel feature-card">
+            <h3>Semester roadmap</h3>
+            <p>
+              Break the plan into realistic semesters so students can see workload, milestone classes,
+              and graduation timing.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section muted-section">
+      <div class="container card-grid two-up">
+        <article class="panel roadmap-card">
+          <p class="eyebrow">Mock roadmap</p>
+          <h2>Next recommended semester</h2>
+          <div class="course-list">
+            <div><span>CS 201</span><strong>Intro to Python</strong></div>
+            <div><span>NET 210</span><strong>Network Fundamentals</strong></div>
+            <div><span>SEC 115</span><strong>Security Principles</strong></div>
+            <div><span>ENG 102</span><strong>Composition II</strong></div>
+          </div>
+        </article>
+
+        <article class="panel roadmap-card">
+          <p class="eyebrow">Career preview</p>
+          <h2>Possible salary outcomes</h2>
+          <div class="salary-stack">
+            <div><span>IT Support Specialist</span><strong>$48k - $62k</strong></div>
+            <div><span>Security Analyst</span><strong>$72k - $96k</strong></div>
+            <div><span>Systems Analyst</span><strong>$68k - $89k</strong></div>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/pathpilot-frontend/templates/results.html
+++ b/pathpilot-frontend/templates/results.html
@@ -1,0 +1,109 @@
+{% extends "base.html" %}
+{% block title %}PlanPilot | Results{% endblock %}
+
+{% block content %}
+<section class="section results-hero">
+  <div class="container">
+    <p class="eyebrow">Generated from mock data</p>
+    <h1>Recommended degree path for Sean Johnson</h1>
+    <p class="lead narrow">
+      Based on 27 completed credits, preference for tech roles, and a goal to finish within
+      4 semesters, PlanPilot ranks the Cybersecurity A.A.S. as the best-fit program.
+    </p>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container card-grid two-up">
+    <article class="panel result-card accent-border">
+      <p class="label">Best-fit program</p>
+      <h2>Cybersecurity A.A.S.</h2>
+      <p>Confidence score: <strong>91%</strong></p>
+      <ul class="bullet-list">
+        <li>Builds on completed intro computing credits</li>
+        <li>Strong alignment with security and support roles</li>
+        <li>Can be completed by Spring 2027</li>
+      </ul>
+    </article>
+
+    <article class="panel result-card">
+      <p class="label">Alternative path</p>
+      <h2>Information Technology Certificate</h2>
+      <p>Confidence score: <strong>78%</strong></p>
+      <ul class="bullet-list">
+        <li>Shorter path to completion</li>
+        <li>Good for help desk and junior admin roles</li>
+        <li>Lower long-term salary ceiling</li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+<section class="section muted-section">
+  <div class="container">
+    <div class="section-heading">
+      <p class="eyebrow">Semester-by-semester</p>
+      <h2>Suggested course plan</h2>
+    </div>
+
+    <div class="timeline">
+      <div class="timeline-item panel">
+        <h3>Fall 2026</h3>
+        <p>CS 201, SEC 115, NET 210, ENG 102</p>
+      </div>
+
+      <div class="timeline-item panel">
+        <h3>Spring 2027</h3>
+        <p>SEC 220, DB 205, MATH 115, Humanities Elective</p>
+      </div>
+
+      <div class="timeline-item panel">
+        <h3>Summer 2027</h3>
+        <p>Internship, Security Lab, Capstone Prep</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-heading">
+      <p class="eyebrow">Career outcomes</p>
+      <h2>Sample role matches</h2>
+    </div>
+
+    <div class="table-wrap panel">
+      <table>
+        <thead>
+          <tr>
+            <th>Role</th>
+            <th>Salary Range</th>
+            <th>Match</th>
+            <th>Outlook</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Security Analyst</td>
+            <td>$72k - $96k</td>
+            <td>High</td>
+            <td>Growing</td>
+          </tr>
+          <tr>
+            <td>IT Support Specialist</td>
+            <td>$48k - $62k</td>
+            <td>Medium</td>
+            <td>Stable</td>
+          </tr>
+          <tr>
+            <td>Systems Analyst</td>
+            <td>$68k - $89k</td>
+            <td>Medium</td>
+            <td>Growing</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
Create base, index, and results templates for the degree and career planner UI. Add initial CSS for layout, navigation, cards, responsive sections, and mock student planning data. this is a concept and is subject to change!
<img width="1728" height="903" alt="Screenshot 2026-04-20 at 7 05 41 AM" src="https://github.com/user-attachments/assets/e07b00b0-68dd-48f7-a9a0-bc121464365f" />
<img width="1728" height="875" alt="Screenshot 2026-04-20 at 7 06 14 AM" src="https://github.com/user-attachments/assets/b55143ea-f036-4474-be19-d571cfccec42" />
